### PR TITLE
Updated README to use the new install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,14 +90,27 @@ If you don't want to remove the go.mod, try the following page
 
 ## Installation
 
+To install, run:
 ```
-$ go install github.com/sago35/tinygo-edit@latest
+go install github.com/sago35/tinygo-edit@latest
 ```
+Be sure that you have added your GOBIN to the PATH.
+You can find your GOBIN by running ```go env```.
 
+### If GOBIN is empty
+The command below should be added to your ```.bashrc``` or ```.zshrc```.
+```
+export PATH="$HOME/go/bin/:$PATH"
+```
+### If GOBIN is not empty
+The command below should be added to your ```.bashrc``` or ```.zshrc```.
+```
+export PATH="$GOBIN:$PATH"
+```
 ## Build
 
 ```
-$ go build
+go build
 ```
 
 ### Environment

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ You can find your GOBIN by running ```go env```.
 ### If GOBIN is empty
 The command below should be added to your ```.bashrc``` or ```.zshrc```.
 ```
-export PATH="$HOME/go/bin/:$PATH"
+export PATH="$GOPATH/bin/:$PATH"
 ```
 ### If GOBIN is not empty
 The command below should be added to your ```.bashrc``` or ```.zshrc```.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If you don't want to remove the go.mod, try the following page
 ## Installation
 
 ```
-$ go get github.com/sago35/tinygo-edit
+$ go install github.com/sago35/tinygo-edit@latest
 ```
 
 ## Build


### PR DESCRIPTION
Installing executables with 'go get' in module mode is deprecated.
Use 'go install pkg@version' instead.
For more information, see https://golang.org/doc/go-get-install-deprecation